### PR TITLE
Better compatibility

### DIFF
--- a/lib/multipass.rb
+++ b/lib/multipass.rb
@@ -145,7 +145,7 @@ class MultiPass
   if Object.const_defined?(:ActiveSupport)
     def decode_json(data, s)
       ActiveSupport::JSON.decode(s)
-    rescue ActiveSupport::JSON::ParseError
+    rescue ActiveSupport::JSON.parse_error
       raise MultiPass::JSONError.new(data, s)
     end
   else


### PR DESCRIPTION
- ActiveSupport::Base64 was removed in ActiveSupport 4.0.0. So check strictly.
- use ActiveSupport::JSON.parse_error instead, more compat.
