### PR TITLE
fix rails3 to rails4 Base64 constant missing bug

### DIFF
--- a/lib/multipass.rb
+++ b/lib/multipass.rb
@@ -1,5 +1,6 @@
 require 'time'
 require 'ezcrypto'
+require 'base64'
 
 class MultiPass
   class Invalid < StandardError


### PR DESCRIPTION
fix rails3 updated to rails4, Base64 constant is not defined